### PR TITLE
Added draft status to projects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def require_public_or_admin!(project_id)
+    project = Project.find(project_id)
+
+    if (! project.is_published? && ! current_user.is_admin?)
+      redirect_to root_path
+    end
+  end
+
   def id_from_hashid(hashid)
     hashids = Hashids.new(HashidConfig.config[:salt])
     return hashids.decode(hashid)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,17 +2,18 @@ class ProjectsController < ApplicationController
 
   before_filter :authenticate_user!, except: [:show, :index, :preview]
   before_filter :require_project_admin!, only: [:edit, :update]
+  before_action -> ( param = params[:id] ) { require_public_or_admin! param }, only: %i|show|
 
   def index
-    @project = Project.where(featured: true).first
+    @project = Project.published.where(featured: true).first
     if(@project.nil?)
-      @project = Project.last
+      @project = Project.published.last
     end
     @activity = []
     if(@project)
       @activity = @project.print_jobs.order('updated_at DESC').limit(8)
     end
-    @older_projects = Project.where(complete: true).order('updated_at DESC')
+    @older_projects = Project.published.where(complete: true).order('updated_at DESC')
   end
 
   def show

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,8 @@ class Project < ActiveRecord::Base
   has_many :print_jobs
   has_and_belongs_to_many :editors, class_name: 'User', join_table: 'projects_editors'
 
+  scope :published, -> { where("status = 'published'") }
+
   def part_available?
     avail_count = Part.where(project_id: id).available.size
     avail_count > parts_in_reserve
@@ -129,5 +131,13 @@ class Project < ActiveRecord::Base
 
   def layers
     parts.map{|p| p.offset.split(',')[2].to_i }.uniq.sort
+  end
+
+  def is_published?
+    self.status == "published"
+  end
+
+  def is_draft?
+    self.status == "draft"
   end
 end

--- a/db/migrate/20200323164509_add_status_to_projects.rb
+++ b/db/migrate/20200323164509_add_status_to_projects.rb
@@ -1,0 +1,10 @@
+class AddStatusToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :status, :string, default: "draft"
+
+    Project.find_each do |project|
+      project.status = 'published'
+      project.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180915193536) do
+ActiveRecord::Schema.define(version: 20200323164509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,35 +20,35 @@ ActiveRecord::Schema.define(version: 20180915193536) do
     t.integer  "part_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "file_file_name",      limit: 255
-    t.string   "file_content_type",   limit: 255
-    t.integer  "file_file_size"
+    t.string   "file_file_name"
+    t.string   "file_content_type"
+    t.integer  "file_file_size",      limit: 8
     t.datetime "file_updated_at"
-    t.integer  "render_state",                    default: 0
-    t.string   "render_file_name",    limit: 255
-    t.string   "render_content_type", limit: 255
-    t.integer  "render_file_size"
+    t.integer  "render_state",                  default: 0
+    t.string   "render_file_name"
+    t.string   "render_content_type"
+    t.integer  "render_file_size",    limit: 8
     t.datetime "render_updated_at"
   end
 
   create_table "part_colors", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.string   "label",       limit: 255
-    t.string   "description", limit: 255
+    t.string   "name"
+    t.string   "label"
+    t.string   "description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "parts", force: :cascade do |t|
     t.integer  "project_id"
-    t.string   "offset",           limit: 255
-    t.string   "extents",          limit: 255
+    t.string   "offset"
+    t.string   "extents"
     t.float    "volume"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "print_jobs_count"
-    t.string   "part_label",       limit: 255
-    t.integer  "desired_color_id",             default: 1, null: false
+    t.string   "part_label"
+    t.integer  "desired_color_id", default: 1, null: false
   end
 
   add_index "parts", ["project_id"], name: "index_parts_on_project_id", using: :btree
@@ -57,31 +57,32 @@ ActiveRecord::Schema.define(version: 20180915193536) do
     t.integer  "user_id"
     t.integer  "project_id"
     t.integer  "part_id"
-    t.string   "aasm_state",         limit: 255
-    t.string   "measurements",       limit: 255
-    t.string   "shipping_info",      limit: 255
+    t.string   "aasm_state"
+    t.string   "measurements"
+    t.string   "shipping_info"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "photo_file_name",    limit: 255
-    t.string   "photo_content_type", limit: 255
-    t.integer  "photo_file_size"
+    t.string   "photo_file_name"
+    t.string   "photo_content_type"
+    t.integer  "photo_file_size",    limit: 8
     t.datetime "photo_updated_at"
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string   "name",                       limit: 255
+    t.string   "name"
     t.text     "description"
-    t.string   "preview_stl",                limit: 255
+    t.string   "preview_stl"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "preview_img",                limit: 255
+    t.string   "preview_img"
     t.boolean  "featured"
     t.boolean  "complete"
     t.text     "shipping_address"
-    t.integer  "parts_in_reserve",                       default: 0, null: false
+    t.integer  "parts_in_reserve",           default: 0,       null: false
     t.string   "print_settings"
     t.string   "marking_instructions"
     t.string   "marking_instructions_photo"
+    t.string   "status",                     default: "draft"
   end
 
   create_table "projects_editors", id: false, force: :cascade do |t|
@@ -99,10 +100,10 @@ ActiveRecord::Schema.define(version: 20180915193536) do
     t.integer  "user_id"
     t.string   "avatar_file_name"
     t.string   "avatar_content_type"
-    t.integer  "avatar_file_size"
+    t.integer  "avatar_file_size",    limit: 8
     t.datetime "avatar_updated_at"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
   end
 
   add_index "teams", ["project_id"], name: "index_teams_on_project_id", using: :btree
@@ -114,23 +115,23 @@ ActiveRecord::Schema.define(version: 20180915193536) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                         limit: 255, default: "",    null: false
-    t.string   "name",                          limit: 255, default: "",    null: false
-    t.string   "avatar",                        limit: 255
-    t.string   "password",                      limit: 255, default: "",    null: false
+    t.string   "email",                         default: "",    null: false
+    t.string   "name",                          default: "",    null: false
+    t.string   "avatar"
+    t.string   "password",                      default: "",    null: false
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                             default: 0,     null: false
+    t.integer  "sign_in_count",                 default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",            limit: 255
-    t.string   "last_sign_in_ip",               limit: 255
-    t.string   "provider",                      limit: 255
-    t.string   "uid",                           limit: 255
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "provider"
+    t.string   "uid"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "is_admin"
     t.string   "secondary_email"
-    t.boolean  "secondary_email_confirmed",                 default: false
+    t.boolean  "secondary_email_confirmed",     default: false
     t.string   "secondary_email_confirm_token"
     t.integer  "max_part_size"
   end


### PR DESCRIPTION
Adds draft status to projects and filters project index to only display
published projects. Existing projects are set to published and new
projects are set to draft by default. Trying to view a challenge that
isn't published if you aren't an admin will redirect you to the
root_path currently.