### PR TITLE
Revert "Bump uri from 0.10.0 to 0.10.0.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 6.0'
 # 2023-03-27 hacks for redefined constant warnings
 # https://stackoverflow.com/questions/70443856/ruby-2-7-4-net-constant-warnings
 gem 'net-http'
-gem 'uri', '0.10.0.1'  # force the default version for ruby 2.7
+gem 'uri', '0.10.0'    # force the default version for ruby 2.7
 
 # Use postgresql for Active Record
 gem "pg", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    uri (0.10.0.1)
+    uri (0.10.0)
     validates_email_format_of (1.7.2)
       i18n
     version_gem (1.1.2)
@@ -307,7 +307,7 @@ DEPENDENCIES
   redcarpet (~> 3.5)
   sass-rails (~> 5.0)
   uglifier (>= 4.2.0)
-  uri (= 0.10.0.1)
+  uri (= 0.10.0)
   validates_email_format_of
 
 RUBY VERSION


### PR DESCRIPTION
Reverts martymcguire/epluribus#53

the uri gem is required internally as a part of rails so shouldn't be manipulating versions outside that?